### PR TITLE
[FEATURE] Add path tracking state

### DIFF
--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -9,9 +9,14 @@ export type Step = [
   ...never[], // Fixed length tuple
 ];
 
+export interface GremlinState {
+  as?: Map<string, IVertex>,
+  path?: Array<IVertex>,
+}
+
 export interface Gremlin {
   vertex: IVertex,
-  state: State,
+  state: GremlinState,
   result?: any,
 }
 
@@ -22,7 +27,6 @@ export interface State {
   edges: IEdge[],
   gremlin: Gremlin,
   taken: number,
-  as: Map<string, IVertex>,
 }
 
 export interface IQueryPrototype {
@@ -90,9 +94,10 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
       }
     }
 
-    return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
-      return gremlin.result != null
-           ? gremlin.result : gremlin.vertex; } ) as any[];
+    return results;
+    // return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
+    //   return gremlin.result != null
+    //        ? gremlin.result : gremlin.vertex; } ) as any[];
   };
 
 


### PR DESCRIPTION
Add path tracking state to query results. 

Interface is in-flux: Here we are returning Gremlins as results instead of vectors in order to attach path tracking state to each result. However, we may want to send a formatted result object in the future to keep internally focused state (such as Gremlin 'aliases') from the results. 

Additionally, sending path state as a response with every request seems unnecessary. Making it an optional parameter seems okay, but increases the complexity of the query interface.