### PR TITLE
[FEATURE] Add target pipetype

### DIFF
--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -145,6 +145,32 @@ export function hydrate(bgraph: IBGraph): void {
     return gremlin;
   });
 
+  // TODO: Update args type to indicate first argument should be an object or function
+  bgraph.addPipetype('target', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+    if(!gremlin) return 'pull'; // Initialize query
+
+    if(typeof args[0] == 'object') {
+      if (bgraph.objectFilter(gremlin.vertex, args[0])) {
+        // Mark gremlin as target
+        gremlin.state.isResult = true;
+      }
+      return gremlin;
+    }
+
+    if(typeof args[0] != 'function') {
+      bgraph.error('Filter arg must be function or object: ' + args[0]);
+      return gremlin;
+    }
+
+    if(args[0](gremlin.vertex, gremlin)) {
+      // Mark gremlin as target
+      gremlin.state.isResult = true;
+      return gremlin;
+    }
+    // Pass all Gremlin's forward
+    return gremlin;
+  });
+
   // TODO: Take could be used to return result batches so user can process asynchronously
   bgraph.addPipetype('take', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
     state.taken = state.taken || 0; // Initialize state

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -9,9 +9,14 @@ export type Step = [
   ...never[], // Fixed length tuple
 ];
 
+export interface GremlinState {
+  as?: Map<string, IVertex>,
+  path?: Array<IVertex>,
+}
+
 export interface Gremlin {
   vertex: IVertex,
-  state: State,
+  state: GremlinState,
   result?: any,
 }
 
@@ -22,7 +27,6 @@ export interface State {
   edges: IEdge[],
   gremlin: Gremlin,
   taken: number,
-  as: Map<string, IVertex>,
 }
 
 export interface IQueryPrototype {
@@ -90,9 +94,10 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
       }
     }
 
-    return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
-      return gremlin.result != null
-           ? gremlin.result : gremlin.vertex; } ) as any[];
+    return results;
+    // return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
+    //   return gremlin.result != null
+    //        ? gremlin.result : gremlin.vertex; } ) as any[];
   };
 
 

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -12,6 +12,7 @@ export type Step = [
 export interface GremlinState {
   as?: Map<string, IVertex>,
   path?: Array<IVertex>,
+  isResult?: boolean,
 }
 
 export interface Gremlin {
@@ -91,6 +92,17 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
         }
         maybe_gremlin = false;
         pc--; // Move program back a step
+        continue;
+      }
+
+      if (maybe_gremlin != false && maybe_gremlin.state.isResult) {
+        // TODO: Prematurely adding a gremlin to the results causes unexpected behaviour
+        //       for the user such as the unique pipe no longer working. Consider cloning
+        //       and suspending Gremlins until unsuspended ie:
+        // `G.v().suspend('s1', {color: 'green'}).out().in().unsuspend('s1').unique().run()`
+        results.push(maybe_gremlin);
+        maybe_gremlin.state.isResult = false;
+        continue;
       }
     }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,7 +26,7 @@ export function hydrate(bgraph: IBGraph): void {
   };
 
   bgraph.makeGremlin = function(vertex: IVertex, state: GremlinState): Gremlin {
-    return {vertex, state };
+    return {vertex, state: state || {} };
   };
 
   bgraph.gotoVertex = function(gremlin: Gremlin, vertex: IVertex): Gremlin {


### PR DESCRIPTION
The target pipe allows a user to check for specific vertices and immediately add them to the query results. Example:

```
window.G.v().target({color: 'green'}).out().run()
```

Considerations:
This is likely to change as adding Gremlins to the results immediately is limiting as once added you can't run any additional queries on these Gremlins. What a user may want to do is `suspend` a Gremlin for a few pipes and then `unsuspend` that pipeline to continue operating on it. For example:

```
// The unique pipe in the query below does not act on the vertices with property `color: green`. 
// Preventing a user from removing potential duplicates
bgraph.v().target({color: 'green'}).out().unique().run()
```

```
// A suspend/unsuspend pipe would allow this
bgraph.v().suspend('green', {color: 'green'}).out().unsuspend('green').unique().run()
```