### PR TITLE
[FEATURE] Add repeat transformer

### DIFF
--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -55,6 +55,16 @@ export function hydrate(bgraph: IBGraph): void {
 
   // Built-in Pipetypes TODO: Move to own directory
 
+  bgraph.addPipetype('repeat', function(graph: IGraph, args: any[], maybe_gremlin: MaybeGremlin): MaybeGremlin {
+    // Faux pipetype used to pass type error checking. Removed in transformer step
+    return maybe_gremlin || 'pull';
+  });
+
+  bgraph.addPipetype('start', function(graph: IGraph, args: any[], maybe_gremlin: MaybeGremlin): MaybeGremlin {
+    // Faux pipetype used to pass type error checking. Removed in transformer step
+    return maybe_gremlin || 'pull';
+  });
+
   bgraph.addPipetype('vertex', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State) {
     if(!state.vertices) {
       // Initialize vertices

--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -145,6 +145,32 @@ export function hydrate(bgraph: IBGraph): void {
     return gremlin;
   });
 
+  // TODO: Update args type to indicate first argument should be an object or function
+  bgraph.addPipetype('target', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+    if(!gremlin) return 'pull'; // Initialize query
+
+    if(typeof args[0] == 'object') {
+      if (bgraph.objectFilter(gremlin.vertex, args[0])) {
+        // Mark gremlin as target
+        gremlin.state.isResult = true;
+      }
+      return gremlin;
+    }
+
+    if(typeof args[0] != 'function') {
+      bgraph.error('Filter arg must be function or object: ' + args[0]);
+      return gremlin;
+    }
+
+    if(args[0](gremlin.vertex, gremlin)) {
+      // Mark gremlin as target
+      gremlin.state.isResult = true;
+      return gremlin;
+    }
+    // Pass all Gremlin's forward
+    return gremlin;
+  });
+
   // TODO: Take could be used to return result batches so user can process asynchronously
   bgraph.addPipetype('take', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
     state.taken = state.taken || 0; // Initialize state

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -9,9 +9,14 @@ export type Step = [
   ...never[], // Fixed length tuple
 ];
 
+export interface GremlinState {
+  as?: Map<string, IVertex>,
+  path?: Array<IVertex>,
+}
+
 export interface Gremlin {
   vertex: IVertex,
-  state: State,
+  state: GremlinState,
   result?: any,
 }
 
@@ -22,7 +27,6 @@ export interface State {
   edges: IEdge[],
   gremlin: Gremlin,
   taken: number,
-  as: Map<string, IVertex>,
 }
 
 export interface IQueryPrototype {
@@ -90,9 +94,10 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
       }
     }
 
-    return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
-      return gremlin.result != null
-           ? gremlin.result : gremlin.vertex; } ) as any[];
+    return results;
+    // return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
+    //   return gremlin.result != null
+    //        ? gremlin.result : gremlin.vertex; } ) as any[];
   };
 
 

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -12,6 +12,7 @@ export type Step = [
 export interface GremlinState {
   as?: Map<string, IVertex>,
   path?: Array<IVertex>,
+  isResult?: boolean,
 }
 
 export interface Gremlin {
@@ -91,6 +92,17 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
         }
         maybe_gremlin = false;
         pc--; // Move program back a step
+        continue;
+      }
+
+      if (maybe_gremlin != false && maybe_gremlin.state.isResult) {
+        // TODO: Prematurely adding a gremlin to the results causes unexpected behaviour
+        //       for the user such as the unique pipe no longer working. Consider cloning
+        //       and suspending Gremlins until unsuspended ie:
+        // `G.v().suspend('s1', {color: 'green'}).out().in().unsuspend('s1').unique().run()`
+        results.push(maybe_gremlin);
+        maybe_gremlin.state.isResult = false;
+        continue;
       }
     }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,7 +26,7 @@ export function hydrate(bgraph: IBGraph): void {
   };
 
   bgraph.makeGremlin = function(vertex: IVertex, state: GremlinState): Gremlin {
-    return {vertex, state };
+    return {vertex, state: state || {} };
   };
 
   bgraph.gotoVertex = function(gremlin: Gremlin, vertex: IVertex): Gremlin {


### PR DESCRIPTION
The repeat transformer allows a user to annotate a section of code for repetition. For example:

```
// The following query
G.v({color: 'green'}).start().out().repeat(2).filter({color: 'red'}).run()

// Transforms into
G.v({color: 'green'}).out().out().out().filter({color: 'red'}).run()
```