### PR TITLE
[FEATURE] Add suspend pipe

### DIFF
--- a/examples/src/core/graph.ts
+++ b/examples/src/core/graph.ts
@@ -39,8 +39,23 @@ export function addLayer(controller: GraferController, queryResults, label, colo
     },
   };
 
+  const flattenedQueryResults = [];
   for (let i = 0; i < queryResults.length; i++) {
-    const result = queryResults[i];
+    const result = queryResults[i].result || queryResults[i].vertex;
+    flattenedQueryResults.push(result);
+
+    // Append path query results
+    // TODO: Consider adding a way to flatten paths as a pipeline step
+    const path = queryResults[i].state?.path || [];
+    for (const vertex of path) {
+      flattenedQueryResults.push(vertex);
+    }
+  }
+
+  for (let i = 0; i < flattenedQueryResults.length; i++) {
+    const result = flattenedQueryResults[i];
+
+
     if (result._type === 'node') {
       // Set node color on query result
       result.color = color;

--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -65,6 +65,45 @@ export function hydrate(bgraph: IBGraph): void {
     return maybe_gremlin || 'pull';
   });
 
+  bgraph.addPipetype('suspend', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+    let shouldSuspendGremlin = true;
+
+    if(!gremlin && (!state.gremlins || !state.gremlins.length)) {
+      // Initialize query, request new gremlin from predecessor
+      return 'pull';
+    }
+
+    if(!state.gremlins || !state.gremlins.length) {
+      if((typeof args[0] == 'object' && !bgraph.objectFilter(gremlin.vertex, args[0])) ||
+         (typeof args[0] == 'function' && !args[0](gremlin.vertex, gremlin))) {
+        shouldSuspendGremlin = false;
+      }
+
+      if (shouldSuspendGremlin) {
+        // Initialize state
+        const suspendedGremlinState = bgraph.cloneGremlinState(gremlin.state);
+        suspendedGremlinState.isSuspended = true;
+        const suspendedGremlin = bgraph.makeGremlin(gremlin.vertex, suspendedGremlinState);
+        state.gremlins = [gremlin, suspendedGremlin];
+      } else {
+        state.gremlins = [gremlin];
+      }
+    }
+
+    if(!state.gremlins.length) {
+      // No more suspended gremlins, request new gremlin from predecessor
+      return 'pull';
+    }
+
+    return state.gremlins.pop();
+  });
+
+  bgraph.addPipetype('unsuspend', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+    if(!gremlin) return 'pull'; // Initialize query
+    if (gremlin && gremlin.state.isSuspended) gremlin.state.isSuspended = false; // Unsuspend Gremlin
+    return gremlin;
+  });
+
   bgraph.addPipetype('vertex', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State) {
     if(!state.vertices) {
       // Initialize vertices
@@ -89,6 +128,8 @@ export function hydrate(bgraph: IBGraph): void {
         // Initialize query, request new gremlin from predecessor
         return 'pull';
       }
+
+      if (gremlin && gremlin.state.isSuspended) return gremlin; // Gremlin is suspended do not traverse
 
       if(!state.edges || !state.edges.length) {
         // Initialize state
@@ -128,6 +169,7 @@ export function hydrate(bgraph: IBGraph): void {
 
   bgraph.addPipetype('unique', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
     if(!gremlin) return 'pull'; // Initialize query
+    if (gremlin && gremlin.state.isSuspended) return gremlin; // Gremlin is suspended do not traverse
     if(state[gremlin.vertex._id]) return 'pull'; // Gremlin seen, request new gremlin
     state[gremlin.vertex._id] = true; // Track seen gremlins by attached vertex
     return gremlin;
@@ -136,6 +178,7 @@ export function hydrate(bgraph: IBGraph): void {
   // TODO: Update args type to indicate first argument should be an object or function
   bgraph.addPipetype('filter', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
     if(!gremlin) return 'pull'; // Initialize query
+    if (gremlin && gremlin.state.isSuspended) return gremlin; // Gremlin is suspended do not traverse
 
     if(typeof args[0] == 'object') {
       // Request new gremlin if current gremlin filtered out
@@ -155,31 +198,31 @@ export function hydrate(bgraph: IBGraph): void {
     return gremlin;
   });
 
-  // TODO: Update args type to indicate first argument should be an object or function
-  bgraph.addPipetype('target', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
-    if(!gremlin) return 'pull'; // Initialize query
+    // TODO: Update args type to indicate first argument should be an object or function
+    bgraph.addPipetype('target', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+      if(!gremlin) return 'pull'; // Initialize query
 
-    if(typeof args[0] == 'object') {
-      if (bgraph.objectFilter(gremlin.vertex, args[0])) {
+      if(typeof args[0] == 'object') {
+        if (bgraph.objectFilter(gremlin.vertex, args[0])) {
+          // Mark gremlin as target
+          gremlin.state.isResult = true;
+        }
+        return gremlin;
+      }
+
+      if(typeof args[0] != 'function') {
+        bgraph.error('Filter arg must be function or object: ' + args[0]);
+        return gremlin;
+      }
+
+      if(args[0](gremlin.vertex, gremlin)) {
         // Mark gremlin as target
         gremlin.state.isResult = true;
+        return gremlin;
       }
+      // Pass all Gremlin's forward
       return gremlin;
-    }
-
-    if(typeof args[0] != 'function') {
-      bgraph.error('Filter arg must be function or object: ' + args[0]);
-      return gremlin;
-    }
-
-    if(args[0](gremlin.vertex, gremlin)) {
-      // Mark gremlin as target
-      gremlin.state.isResult = true;
-      return gremlin;
-    }
-    // Pass all Gremlin's forward
-    return gremlin;
-  });
+    });
 
   // TODO: Take could be used to return result batches so user can process asynchronously
   bgraph.addPipetype('take', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {

--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -198,32 +198,6 @@ export function hydrate(bgraph: IBGraph): void {
     return gremlin;
   });
 
-    // TODO: Update args type to indicate first argument should be an object or function
-    bgraph.addPipetype('target', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
-      if(!gremlin) return 'pull'; // Initialize query
-
-      if(typeof args[0] == 'object') {
-        if (bgraph.objectFilter(gremlin.vertex, args[0])) {
-          // Mark gremlin as target
-          gremlin.state.isResult = true;
-        }
-        return gremlin;
-      }
-
-      if(typeof args[0] != 'function') {
-        bgraph.error('Filter arg must be function or object: ' + args[0]);
-        return gremlin;
-      }
-
-      if(args[0](gremlin.vertex, gremlin)) {
-        // Mark gremlin as target
-        gremlin.state.isResult = true;
-        return gremlin;
-      }
-      // Pass all Gremlin's forward
-      return gremlin;
-    });
-
   // TODO: Take could be used to return result batches so user can process asynchronously
   bgraph.addPipetype('take', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
     state.taken = state.taken || 0; // Initialize state

--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -55,6 +55,16 @@ export function hydrate(bgraph: IBGraph): void {
 
   // Built-in Pipetypes TODO: Move to own directory
 
+  bgraph.addPipetype('repeat', function(graph: IGraph, args: any[], maybe_gremlin: MaybeGremlin): MaybeGremlin {
+    // Faux pipetype used to pass type error checking. Removed in transformer step
+    return maybe_gremlin || 'pull';
+  });
+
+  bgraph.addPipetype('start', function(graph: IGraph, args: any[], maybe_gremlin: MaybeGremlin): MaybeGremlin {
+    // Faux pipetype used to pass type error checking. Removed in transformer step
+    return maybe_gremlin || 'pull';
+  });
+
   bgraph.addPipetype('vertex', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State) {
     if(!state.vertices) {
       // Initialize vertices

--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -145,6 +145,32 @@ export function hydrate(bgraph: IBGraph): void {
     return gremlin;
   });
 
+  // TODO: Update args type to indicate first argument should be an object or function
+  bgraph.addPipetype('target', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+    if(!gremlin) return 'pull'; // Initialize query
+
+    if(typeof args[0] == 'object') {
+      if (bgraph.objectFilter(gremlin.vertex, args[0])) {
+        // Mark gremlin as target
+        gremlin.state.isResult = true;
+      }
+      return gremlin;
+    }
+
+    if(typeof args[0] != 'function') {
+      bgraph.error('Filter arg must be function or object: ' + args[0]);
+      return gremlin;
+    }
+
+    if(args[0](gremlin.vertex, gremlin)) {
+      // Mark gremlin as target
+      gremlin.state.isResult = true;
+      return gremlin;
+    }
+    // Pass all Gremlin's forward
+    return gremlin;
+  });
+
   // TODO: Take could be used to return result batches so user can process asynchronously
   bgraph.addPipetype('take', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
     state.taken = state.taken || 0; // Initialize state

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -13,6 +13,7 @@ export interface GremlinState {
   as?: Map<string, IVertex>,
   path?: Array<IVertex>,
   isResult?: boolean,
+  isSuspended?: boolean,
 }
 
 export interface Gremlin {
@@ -28,6 +29,7 @@ export interface State {
   edges: IEdge[],
   gremlin: Gremlin,
   taken: number,
+  gremlins: Gremlin[],
 }
 
 export interface IQueryPrototype {

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -9,9 +9,14 @@ export type Step = [
   ...never[], // Fixed length tuple
 ];
 
+export interface GremlinState {
+  as?: Map<string, IVertex>,
+  path?: Array<IVertex>,
+}
+
 export interface Gremlin {
   vertex: IVertex,
-  state: State,
+  state: GremlinState,
   result?: any,
 }
 
@@ -22,7 +27,6 @@ export interface State {
   edges: IEdge[],
   gremlin: Gremlin,
   taken: number,
-  as: Map<string, IVertex>,
 }
 
 export interface IQueryPrototype {
@@ -90,9 +94,10 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
       }
     }
 
-    return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
-      return gremlin.result != null
-           ? gremlin.result : gremlin.vertex; } ) as any[];
+    return results;
+    // return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
+    //   return gremlin.result != null
+    //        ? gremlin.result : gremlin.vertex; } ) as any[];
   };
 
 

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -12,6 +12,7 @@ export type Step = [
 export interface GremlinState {
   as?: Map<string, IVertex>,
   path?: Array<IVertex>,
+  isResult?: boolean,
 }
 
 export interface Gremlin {
@@ -91,6 +92,17 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
         }
         maybe_gremlin = false;
         pc--; // Move program back a step
+        continue;
+      }
+
+      if (maybe_gremlin != false && maybe_gremlin.state.isResult) {
+        // TODO: Prematurely adding a gremlin to the results causes unexpected behaviour
+        //       for the user such as the unique pipe no longer working. Consider cloning
+        //       and suspending Gremlins until unsuspended ie:
+        // `G.v().suspend('s1', {color: 'green'}).out().in().unsuspend('s1').unique().run()`
+        results.push(maybe_gremlin);
+        maybe_gremlin.state.isResult = false;
+        continue;
       }
     }
 

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -96,22 +96,9 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
         pc--; // Move program back a step
         continue;
       }
-
-      if (maybe_gremlin != false && maybe_gremlin.state.isResult) {
-        // TODO: Prematurely adding a gremlin to the results causes unexpected behaviour
-        //       for the user such as the unique pipe no longer working. Consider cloning
-        //       and suspending Gremlins until unsuspended ie:
-        // `G.v().suspend('s1', {color: 'green'}).out().in().unsuspend('s1').unique().run()`
-        results.push(maybe_gremlin);
-        maybe_gremlin.state.isResult = false;
-        continue;
-      }
     }
 
     return results;
-    // return results.map(function(gremlin) { // Return results collected by gremlins or gremlin vertices
-    //   return gremlin.result != null
-    //        ? gremlin.result : gremlin.vertex; } ) as any[];
   };
 
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -26,7 +26,7 @@ export function hydrate(bgraph: IBGraph): void {
   };
 
   bgraph.makeGremlin = function(vertex: IVertex, state: GremlinState): Gremlin {
-    return {vertex, state };
+    return {vertex, state: state || {} };
   };
 
   bgraph.gotoVertex = function(gremlin: Gremlin, vertex: IVertex): Gremlin {


### PR DESCRIPTION
### Overview:
The `suspend` pipetype takes a set of Gremlins and removes them from being acted upon by the remaining pipes. This allows a user to keep certain Gremlins around while continuing to query the data. For example:

```
// We'd expect the final filter to filter all results. However, since vertices colored red are suspended they are not
// acted upon by the suspended pipe
G.v().suspend({color: 'red'}).filter(v => false).run() // => [...]

// However if we unsuspend our suspended Gremlin's then they can be acted upon by other pipes again
G.v().suspend({color: 'red'}).unsuspend().filter(v => false).run() // => []
```

### Changes:
- Add `suspend` and `unsuspend` pipes
- Remove `target` pipe (Note: The functionality of target can be replaced with suspend/unsuspend + repeat)

### Considerations:
- Suspension causes a Gremlin to be cloned, whereas one Gremlin clone continues down the pipe unsuspended and then the other clone is set as suspended. This may be unexpected behaviour it would be better if we were able to explicitly clone with another pipe. 