### PR TITLE
[BUG] Prevent suspending a previously suspended Gremlin

### DIFF
--- a/src/pipes/pipetypes.ts
+++ b/src/pipes/pipetypes.ts
@@ -66,6 +66,7 @@ export function hydrate(bgraph: IBGraph): void {
   });
 
   bgraph.addPipetype('suspend', function(graph: IGraph, args: any[], gremlin: Gremlin, state: State): PipeResult {
+    if (gremlin && gremlin.state.isSuspended) return gremlin; // Gremlin is suspended do not traverse
     let shouldSuspendGremlin = true;
 
     if(!gremlin && (!state.gremlins || !state.gremlins.length)) {


### PR DESCRIPTION
Prevent Gremlin's that have previously been cloned and suspended from being re-cloned and re-suspended during a `suspend` pipe.

