### PR TITLE
[PERFORMANCE] Improve computation/memory on simple traversals

### DIFF
--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -12,6 +12,11 @@ export interface IVertex extends IVertexProto {
   _in: IEdge[],
 }
 
+export interface IVertexPath {
+  parent?: IVertexPath,
+  vertex: IVertex,
+}
+
 export interface IEdgeProto {
   _out: VertexIndex,
   _in: VertexIndex,

--- a/src/performance.spec.ts
+++ b/src/performance.spec.ts
@@ -23,7 +23,7 @@ describe('traversal performance tests', () => {
     {n: 100,   expected: 5},
     {n: 1000,  expected: 50},
     {n: 10000, expected: 500},
-    {n: 100000, expected: 5000},
+    {n: 100000, expected: 20000},
   ])('traversing $n times from single node cyclic graph', ({n, expected}) => {
     test(`should finish in ${expected}ms`, () => {
       G = bgraph.graph(...buildCyclicGraph(1));

--- a/src/performance.spec.ts
+++ b/src/performance.spec.ts
@@ -22,7 +22,8 @@ describe('traversal performance tests', () => {
   describe.each([
     {n: 100,   expected: 5},
     {n: 1000,  expected: 50},
-    {n: 10000, expected: 5000},
+    {n: 10000, expected: 500},
+    {n: 100000, expected: 5000},
   ])('traversing $n times from single node cyclic graph', ({n, expected}) => {
     test(`should finish in ${expected}ms`, () => {
       G = bgraph.graph(...buildCyclicGraph(1));

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -1,4 +1,4 @@
-import { IGraph, IVertex, IEdge } from "../graph/graph";
+import { IGraph, IVertex, IVertexPath, IEdge } from "../graph/graph";
 import { IBGraph } from "..";
 import { PipeTypes, PipeResult, PipeFunction } from "../pipes/pipetypes";
 
@@ -11,7 +11,7 @@ export type Step = [
 
 export interface GremlinState {
   as?: Map<string, IVertex>,
-  path?: Array<IVertex>,
+  path?: IVertexPath,
   isResult?: boolean,
   isSuspended?: boolean,
 }
@@ -69,7 +69,7 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
 
       maybe_gremlin = pipetype(this.graph, step[1], maybe_gremlin, state);
 
-      if(maybe_gremlin == 'pull') { // 'pull' tells us the pipe wants further input
+      if(maybe_gremlin === 'pull') { // 'pull' tells us the pipe wants further input
         maybe_gremlin = false;
         if(pc-1 > done) {
           pc--; // Move program counter to previous pipe
@@ -79,7 +79,7 @@ export function prototype(bgraph: IBGraph): IQueryPrototype {
         }
       }
 
-      if(maybe_gremlin == 'done') {
+      if(maybe_gremlin === 'done') {
         // Pipe is finished
         maybe_gremlin = false;
         done = pc;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,7 +20,7 @@ export function hydrate(bgraph: IBGraph): void {
       newState.as = state.as;
     }
     if (state?.path) {
-      newState.path = state.path.slice(); // shallow copy path
+      newState.path = state.path; // Point new state to head of path
     }
     return newState as GremlinState;
   };
@@ -33,9 +33,15 @@ export function hydrate(bgraph: IBGraph): void {
     const state = bgraph.cloneGremlinState(gremlin.state);
     if (state.path) {
       // Add current vertex to Gremlin's path
-      state.path.push(gremlin.vertex);
+      const newPath = {
+        vertex: gremlin.vertex,
+        parent: state.path,
+      };
+      state.path = newPath;
     } else {
-      state.path = [gremlin.vertex];
+      state.path = {
+        vertex: gremlin.vertex,
+      };
     }
     return bgraph.makeGremlin(vertex, state); // Clone gremlin
   };


### PR DESCRIPTION
Benchmarks (here Xn-Ye stands for a simple traversal `G.v().out().run()` where X is the number of nodes and Y is number of times out is called):

```
Before:
1n-100r: 1.0743703842163086ms
1n-1000r: 26.232311248779297ms
1n-10000r: 1058.5187377929688ms
10000n-1r: 20.17758846282959ms
100000n-1r: 107.87045478820801ms
1000000n-1r: 853.9200029373169ms

After:
1n-100r: 0.9706020355224609ms
1n-1000r: 5.8925933837890625ms
1n-10000r: 38.375250816345215ms
10000n-1r: 13.655800819396973ms
100000n-1r: 98.51250076293945ms
1000000n-1r: 626.1153287887573ms
```

## Changes:
- Use strict equalities in virtual machine instead of loose equalities to avoid performance loses from coercion.
- Use a linked list instead of an array when storing paths within Gremlin state to avoid memory cost of large shallowly copied arrays and computation cost of array iteration. Just the pointer references in these shallow copies was consuming a lot of memory and iterating through these arrays to perform a shallow copy was slowing down computation.    