### PR TITLE
[PERFORMANCE] Dramatically reduce processing time of larg…

### DIFF
--- a/src/performance.spec.ts
+++ b/src/performance.spec.ts
@@ -22,8 +22,9 @@ describe('traversal performance tests', () => {
   describe.each([
     {n: 100,   expected: 5},
     {n: 1000,  expected: 50},
-    {n: 10000, expected: 500},
-    {n: 100000, expected: 20000},
+    {n: 10000, expected: 100},
+    {n: 100000, expected: 500},
+    {n: 1000000, expected: 5000},
   ])('traversing $n times from single node cyclic graph', ({n, expected}) => {
     test(`should finish in ${expected}ms`, () => {
       G = bgraph.graph(...buildCyclicGraph(1));


### PR DESCRIPTION
## Benchmarks on 'traversing n times from single node cyclic graph' 
See the 'traversing n times from single node cyclic graph' test case in performance test spec for replicating tests.

Before:
```
number of repetitions, query run-time in milliseconds
10: 0.09999990463256836
100: 0.40000009536743164
1000: 5.6000001430511475
10000: 29.5
100000: 3307.300000190735
1000000: DNF
10000000: DNF
```

After:
```
number of repetitions, query run-time in milliseconds
10: 0.09999990463256836 (ms)
100: 0.09999990463256836
1000: 4.200000047683716
10000: 11.199999809265137
100000: 89.29999995231628
1000000: 617.1999998092651
10000000: 7567.300000190735
```